### PR TITLE
Handle mac addresses

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = qmotion-qsync
-version = 0.0.1
+version = 0.0.2
 description = Control Qmotion Gen2 shades using Qsync device
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Immediately found a use case to use the group/scene mac address, so cleaning that up
and using the detailed level mac.

It turns out the UDP is problematic in docker containers, so want to handle as
much as possible over non-UPD discovery (that is, TCP commands) as possible.